### PR TITLE
Allow portier login from a GET request.

### DIFF
--- a/kinto_portier/views.py
+++ b/kinto_portier/views.py
@@ -59,8 +59,6 @@ def colander_querystring_validator(request, schema=None, deserializer=None, **kw
     :param deserializer: Optional deserializer, defaults to
         :func:`cornice.validators.extract_cstruct`
     """
-    import colander
-
     class RequestSchema(colander.MappingSchema):
         querystring = schema
 


### PR DESCRIPTION
Fixes #5 

We should probably not merge that pull-request because it allows sending an email address in a querystring which might be a [privacy concerns](https://blog.httpwatch.com/2009/02/20/how-secure-are-query-strings-over-https/).