### PR TITLE
Try to remove dependency-links usage to fix the build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,6 @@ REQUIREMENTS = [
     'portier-python',
 ]
 
-DEPENDENCY_LINKS = []
-
 ENTRY_POINTS = {}
 
 
@@ -51,5 +49,4 @@ setup(name='kinto-portier',
       zip_safe=False,
       install_requires=REQUIREMENTS,
       extras_require={},
-      dependency_links=DEPENDENCY_LINKS,
       entry_points=ENTRY_POINTS)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ commands =
     py.test --cov-report term-missing --cov-fail-under 100 --cov kinto_portier {posargs}
 deps =
     -rdev-requirements.txt
-install_command = pip install --process-dependency-links --pre {opts} {packages}
+install_command = pip install --pre {opts} {packages}
 
 [testenv:flake8]
 commands = flake8 kinto_portier


### PR DESCRIPTION
pip no longer supports `--process-dependency-links`. I'm not sure we ever needed it or what it actually even does. Per https://github.com/pypa/pip/issues/4187 it seems like it's most useful in handling dependencies that are "private" packages or forks. Let's try to remove it and see if the build is fixed.